### PR TITLE
switch base image to debian and include beta binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,22 @@
-FROM alpine
+FROM java:openjdk-8
 
-RUN apk add --update \
-	bash \
+RUN apt-get update && apt-get install -y \
 	git \
 	curl \
-	libpq \
-	musl-dev \
-	postgresql-dev \
+	libpq-dev \
 	# C \
 	gcc \
-	# Java \
-	openjdk8 \
 	# Python \
-	py-pip \
+	python-pip \
 	python-dev \
-	# Node.js \
-	nodejs \
 	# PHP \
-	php-pgsql \
-	php-pdo \
-	php-pdo_pgsql \
+	php5-pgsql \
 	# Ruby \
 	ruby-pg \
-	&& rm -rf /var/cache/apk/*
+	&& rm -rf /var/lib/apt/lists/*
+
+# Debian's stock node package doesn't include npm.
+RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - && apt-get install -y nodejs
 
 RUN pip install psycopg2
 
@@ -31,3 +25,10 @@ RUN npm install pg
 RUN curl -SL https://jdbc.postgresql.org/download/postgresql-9.4.1207.jar > /postgres.jar
 
 RUN git clone https://github.com/cockroachdb/finagle-postgres.git && cd finagle-postgres && git checkout fatjartests && ./sbt assembly && mv target/scala-2.11/finagle-postgres-tests.jar /
+
+# Download a reference binary that tests can run against.
+ENV REFERENCE_VERSION="beta-20160407"
+
+RUN mkdir /reference-version && \
+	curl -SL https://binaries.cockroachdb.com/cockroach-${REFERENCE_VERSION}.linux-amd64.tgz | tar xvz -C /tmp && \
+	mv /tmp/cockroach-${REFERENCE_VERSION}*/* /reference-version


### PR DESCRIPTION
paves the way for acceptance tests that want to check against out published binaries.
Our binaries require glibc, so the base image is changed to an alpine variant to include it.
