### PR TITLE
combine apt-get calls and re-include php cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
 FROM java:openjdk-8
 
-RUN apt-get update && apt-get install -y \
+# Debian's stock node package doesn't include npm.
+RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
+	apt-get install -y \
 	git \
 	curl \
 	libpq-dev \
+	postgresql \
 	# C \
 	gcc \
+	# Node
+	nodejs \
 	# Python \
 	python-pip \
 	python-dev \
 	# PHP \
+	php5-cli \
 	php5-pgsql \
 	# Ruby \
 	ruby-pg \
 	&& rm -rf /var/lib/apt/lists/*
-
-# Debian's stock node package doesn't include npm.
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - && apt-get install -y nodejs
 
 RUN pip install psycopg2
 


### PR DESCRIPTION
Cleans up a couple mistakes introduced in #4 related to switching to apt-get:
- re-introduce php cli which got lost in shuffle
- add postgres explicitly since libpq-dev doesn't pull it in
- combine apt-get calls into single RUN to minimize layer bloat.
