### PR TITLE
update readme to reflect current workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Postgres Test
 
-This repo contains one branch per language for the cockroach acceptance tests.
-These are auto-built on push and tagged on the docker hub at
-https://hub.docker.com/r/cockroachdb/postgres-test/.
+This is the Docker image used to run the CockroachDB
+[acceptance tests](https://github.com/cockroachdb/cockroach/tree/master/acceptance),
+which include verification that simple clients in various languages can connect
+to and interact with CockroachDB using the Postgres wire protocol -- thus it
+includes the tools required to run php, node, java, etc.
+
+[Docker Hub](https://hub.docker.com/r/cockroachdb/postgres-test/) automatically
+builds new images from git tags, using the git tag as the Docker tag. By
+convention, tags are of the form YYYYMMDD-HHMM.

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-tag="$(date +%Y%m%d-%H%M%S)"
-docker build -t cockroachdb/postgres-test:${tag} .


### PR DESCRIPTION
At some point (fd564519) we switched to an all-in-one image and more recently
switch dockerhub to auto-build tags, so this is just updating the README to
reflect the current workflow in practice.
