### PR TITLE
remove reference binaries from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM java:openjdk-8
 
-ENV FORWARD_REFERENCE_VERSION="beta-20160414"
-ENV BIDIRECTIONAL_REFERENCE_VERSION="beta-20160629"
-
 # See README in that directory.
-ADD cockroach-data-${FORWARD_REFERENCE_VERSION} /cockroach-data-reference-7429
+ADD cockroach-data-beta-20160414 /cockroach-data-reference-7429
 
 # Debian's stock node package doesn't include npm.
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
@@ -39,13 +36,3 @@ RUN git clone --depth 1 -b fatjartests https://github.com/cockroachdb/finagle-po
 	./sbt assembly && \
 	mv target/scala-2.11/finagle-postgres-tests.jar / && \
 	cd / && rm -rf /finagle-postgres ~/.ivy2
-
-# Download a reference binary that forward tests can run against.
-RUN mkdir /forward-reference-version && \
-	curl -SL https://binaries.cockroachdb.com/cockroach-${FORWARD_REFERENCE_VERSION}.linux-amd64.tgz | tar xvz -C /tmp && \
-	mv /tmp/cockroach-${FORWARD_REFERENCE_VERSION}*/* /forward-reference-version
-
-# Download a reference binary that bidirectional tests can run against.
-RUN mkdir /bidirectional-reference-version && \
-	curl -SL https://binaries.cockroachdb.com/cockroach-${BIDIRECTIONAL_REFERENCE_VERSION}.linux-amd64.tgz | tar xvz -C /tmp && \
-	mv /tmp/cockroach-${BIDIRECTIONAL_REFERENCE_VERSION}*/* /bidirectional-reference-version


### PR DESCRIPTION
They don't really belong here. An upcoming cockroachdb change will download them instead.
